### PR TITLE
Add image deletion functionality (Trashbin simbol)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,6 +76,15 @@ class TierListPageState extends State<TierListPage> {
     });
   }
 
+  void _deleteImage(ImageData image) {
+    setState(() {
+      for (var customer in customers) {
+        customer.items.remove(image);
+      }
+      images.remove(image);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -137,6 +146,7 @@ class TierListPageState extends State<TierListPage> {
                       }
                     },
                     onEditImageText: _editImageText,
+                    onDeleteImage: _deleteImage, // Pass the delete function
                   ),
                 ),
               ],
@@ -196,6 +206,16 @@ class TierListPageState extends State<TierListPage> {
                 icon: const Icon(Icons.edit, color: Colors.white),
                 onPressed: () {
                   _editImageText(imageData);
+                },
+              ),
+            ),
+            Positioned(
+              top: 4,
+              right: 4,
+              child: IconButton(
+                icon: const Icon(Icons.delete, color: Colors.red, size: 20),
+                onPressed: () {
+                  _deleteImage(imageData);
                 },
               ),
             ),
@@ -572,6 +592,7 @@ class CustomerCart extends StatelessWidget {
     required this.editMode,
     required this.onImageDropped,
     required this.onEditImageText,
+    required this.onDeleteImage, // Add this line
   });
 
   final Customer customer;
@@ -580,6 +601,7 @@ class CustomerCart extends StatelessWidget {
   final bool editMode;
   final Function(ImageData) onImageDropped;
   final Function(ImageData) onEditImageText;
+  final Function(ImageData) onDeleteImage; // Add this line
 
   @override
   Widget build(BuildContext context) {
@@ -594,7 +616,7 @@ class CustomerCart extends StatelessWidget {
           return ListView(
             scrollDirection: Axis.horizontal,
             children: [
-              ...customer.items.map((item) => buildDraggableImage(item)),
+              ...customer.items.map((item) => buildDraggableImage(item, context)),
             ],
           );
         },
@@ -608,9 +630,9 @@ class CustomerCart extends StatelessWidget {
     );
   }
 
-  Widget buildDraggableImage(ImageData imageData) {
+  Widget buildDraggableImage(ImageData imageData, BuildContext context) {
     return crossOutMode || editMode
-        ? buildImage(imageData)
+        ? buildImage(imageData, context)
         : Draggable<ImageData>(
             data: imageData,
             feedback: Material(
@@ -650,7 +672,7 @@ class CustomerCart extends StatelessWidget {
               ),
             ),
             childWhenDragging: Container(), // Display an empty container when dragging
-            child: buildImage(imageData),
+            child: buildImage(imageData, context),
             onDraggableCanceled: (velocity, offset) {
               if (crossOutMode || editMode) {
                 return;
@@ -660,7 +682,7 @@ class CustomerCart extends StatelessWidget {
           );
   }
 
-  Widget buildImage(ImageData imageData) {
+  Widget buildImage(ImageData imageData, BuildContext context) {
     return GestureDetector(
       onTap: () {
         if (crossOutMode) {
@@ -705,6 +727,17 @@ class CustomerCart extends StatelessWidget {
                 icon: const Icon(Icons.edit, color: Colors.white),
                 onPressed: () {
                   onEditImageText(imageData);
+                },
+              ),
+            ),
+            Positioned(
+              top: 4,
+              right: 4,
+              child: IconButton(
+                icon: const Icon(Icons.delete, color: Colors.red, size: 20),
+                onPressed: () {
+                  onDeleteImage(imageData);
+                  (context as Element).markNeedsBuild();
                 },
               ),
             ),


### PR DESCRIPTION
This pull request adds functionality to delete images from the tier list and customer carts. The most important changes include adding a method to handle image deletion, updating the UI to include a delete button, and passing the delete function through the widget tree.

Functionality to delete images:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R79-R87): Added the `_deleteImage` method to the `TierListPageState` class to remove images from both the main list and customer items.
* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R595): Updated the `CustomerCart` class to include a new `onDeleteImage` parameter and modified the `buildImage` method to display a delete button when in edit mode. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R595) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R604) [[3]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L597-R619) [[4]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L611-R635) [[5]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L653-R675) [[6]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L663-R685) [[7]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R733-R743)

UI updates:

* [`lib/main.dart`](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R212-R221): Added a delete button to the image widgets in both the `TierListPageState` and `CustomerCart` classes, which calls the `_deleteImage` method when pressed. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R212-R221) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R733-R743)